### PR TITLE
color指定に大文字可能にする

### DIFF
--- a/bin/utility/create_color.js
+++ b/bin/utility/create_color.js
@@ -28,7 +28,7 @@ function create_color (color, options) {
     return ch.rgb(template_color[0], template_color[1], template_color[2])
   }
 
-  let hex = color.match(/^#?([0-9a-f]+)$/)
+  let hex = color.match(/^#?([0-9a-fA-F]+)$/)
   if (hex) {
     return ch.hex("#" + hex[1])
   }


### PR DESCRIPTION
#72 
第3引数のcolor指定に大文字だと弾かれるバグを修正

16進のフォーマット確認にA-Fを追加しました