### PR TITLE
色を定義できるようにする

### DIFF
--- a/bin/colter.js
+++ b/bin/colter.js
@@ -15,6 +15,7 @@ const convert_JSON = require('./utility/convert_JSON')
 const ls = require('./utility/ls')
 const confirm = require('prompt-confirm');
 const check_settings_init = require('./utility/check_settings_init')
+const color_template = require('./utility/color_template')
 
 let data = opt.run()
 
@@ -60,6 +61,18 @@ let color = data.targets[1]
 let chalk = create_color(color, data.options)
 if (chalk == undefined) {
   console.log('please color')
+  return
+}
+
+if (data.options.var) {
+  let template = color_template.get()
+  template[pattern] = {
+    color: color,
+    options: {
+      bold: Boolean(data.options.bold),
+      itelic: Boolean(data.options.italic),
+    }}
+  color_template.save(template)
   return
 }
 

--- a/bin/options.js
+++ b/bin/options.js
@@ -22,6 +22,11 @@ argv.option([
   description: '色を初期状態に戻します',
   example: "'colter --reset'"
 }, {
+  name: 'var',
+  type: 'bool',
+  description: '色に名前を付けておきます',
+  example: "'colter --var orange fa0'"
+}, {
   name: 'bold',
   type: 'bool',
   description: '太字を指定します',

--- a/bin/settings.js
+++ b/bin/settings.js
@@ -1,6 +1,7 @@
 let settings = {
-  rc: ".colter",
-  colorrc: "color_setting.txt"
+  rc: '.colter',
+  colorrc: 'color_setting.txt',
+  color_template: 'color_template.json',
 }
 
 module.exports = settings

--- a/bin/utility/color_template.js
+++ b/bin/utility/color_template.js
@@ -1,0 +1,30 @@
+const fs = require('fs')
+const os = require('os')
+const settings = require('../settings')
+const path = `${os.homedir()}/${settings.rc}/${settings.color_template}`
+
+function get() {
+  try {
+    return JSON.parse(fs.readFileSync(path).toString())
+  } catch {
+    const opt = { bold: false, italic: false }
+    const default_template = {
+      red: { color: '#f00', options: opt },
+      green: { color: '#0f0', options: opt },
+      blue: { color: '#00f', options: opt },
+      yellow: { color: '#ff0', options: opt },
+    }
+
+    fs.writeFile(path, JSON.stringify(default_template), err => {})
+    return default_template
+  }
+}
+
+function save(template) {
+  fs.writeFile(path, JSON.stringify(template, null, '  '), err => {})
+}
+
+module.exports = {
+  get,
+  save,
+}

--- a/bin/utility/create_color.js
+++ b/bin/utility/create_color.js
@@ -1,36 +1,35 @@
 const chalk = require('chalk')
-function create_color (color, options) {
-  if (color == undefined) {
-    return undefined
-  }
+const color_template = require('./color_template')
 
-  let ch = chalk;
+function add_option(ch, options) {
   if (options.bold) {
     ch = ch.bold;
   }
   if (options.italic) {
     ch = ch.italic;
   }
+  return ch
+}
+
+function create_color (color, options) {
+  if (color == undefined) {
+    return undefined
+  }
 
   let rgb = color.match(/^rgb[^a-zA-Z0-9]? *(\d+)[., ] *(\d+)[., ] *(\d+) *[^a-zA-Z]?$/)
   if (rgb) {
-    return ch.rgb(rgb[1], rgb[2], rgb[3])
+    return add_option(chalk.rgb(rgb[1], rgb[2], rgb[3]), options)
   }
 
-  let template = {
-    red: [255, 0, 0],
-    green: [0, 255, 0],
-    blue: [0, 0, 255],
-    yellow: [255, 255, 0],
-  }
-  let template_color = template[color]
-  if (template_color != undefined) {
-    return ch.rgb(template_color[0], template_color[1], template_color[2])
+  const template = color_template.get()[color]
+  if (template != undefined) {
+    const chalk_color = create_color(template.color, template.options)
+    return add_option(chalk_color, options)
   }
 
   let hex = color.match(/^#?([0-9a-fA-F]+)$/)
   if (hex) {
-    return ch.hex("#" + hex[1])
+    return add_option(chalk.hex("#" + hex[1]), options)
   }
 
   // more


### PR DESCRIPTION
# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
#63 色のテンプレートをユーザーが作れるようにする

## 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
* --varオプションを追加しました
```
atam --var orange fa0
atam DIR orange
```
みたいな感じです

* 太文字とかも保存します
`atam --var orange fa0 --bold`

* 設定の保存先は`<home>/.colter/color_template.json`です
手で修正が加えやすいように整形して出力しています

* helpにvarが追加されました

## 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->

## 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->

## 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
